### PR TITLE
Update address change endpoint

### DIFF
--- a/main/spiders/locations.py
+++ b/main/spiders/locations.py
@@ -14,7 +14,7 @@ class AmazonLocationSessionSpider(Spider):
 
     name = "amazon:location-session"
 
-    address_change_endpoint = "/gp/delivery/ajax/address-change.html"
+    address_change_endpoint = "/portal-migration/hz/glow/address-change?actionSource=glow"
     csrf_token_endpoint = (
         "/portal-migration/hz/glow/get-rendered-address-selections?deviceType=desktop"
         "&pageType=Search&storeContext=NoStoreName&actionSource=desktop-modal"


### PR DESCRIPTION
Fixes https://github.com/borys25ol/amazon-location-cookies-service/issues/6

I had the same problem mentioned in the issue, changing endpoint fixes it, and now it works perfectly with UK site as well as other region sites including DE, ES, CA, USA, and JP.